### PR TITLE
Add taints and labels to machinepools

### DIFF
--- a/machinepools/templates/_node_defaults.tpl
+++ b/machinepools/templates/_node_defaults.tpl
@@ -14,22 +14,3 @@ taints:
 {{- toYaml $.Values.cloud.cloudpakNodes.taints | nindent 6 -}}
 {{- end -}}
 {{- end -}}
-
-
-{{- define "node.labels" -}}
-{{- if and (eq .Name "storage") $.Values.cloud.storageNodes.labels }}
-metadata:
-  labels:
-{{- toYaml $.Values.cloud.storageNodes.labels | nindent 10 -}}
-{{- end -}}
-{{- if and (eq .Name "infra") $.Values.cloud.infraNodes.labels }}
-metadata:
-  labels:
-{{- toYaml $.Values.cloud.infraNodes.labels | nindent 10 -}}
-{{- end -}}
-{{- if and (eq .Name "cp4x") $.Values.cloud.cloudpakNodes.labels }}
-metadata:
-  labels:
-{{- toYaml $.Values.cloud.cloudpakNodes.labels | nindent 10 -}}
-{{- end -}}
-{{- end -}}

--- a/machinepools/values.yaml
+++ b/machinepools/values.yaml
@@ -57,17 +57,10 @@ global:
       - effect: "NoSchedule"
         key: "node-role.kubernetes.io/infra"
         value: ""
-    labels:
-      node-role.kubernetes.io/infra: ""
   storageNodes:
     taints:
       - effect: "NoSchedule"
         key: "node.ocs.openshift.io/storage"
         value: "true"
-    labels:
-      node-role.kubernetes.io/infra: ""
-      cluster.ocs.openshift.io/openshift-storage: ""
   cloudpakNodes:
     taints:
-    labels:
-      node-role.kubernetes.io/cp4x: ""


### PR DESCRIPTION
When machinepools are created, the helm chart will now automatically apply the taints and labels required to allow additional components to be deployed that have tolerations. An example would be ODF and deploying on "storage" nodes only.